### PR TITLE
fix: Display directories correctly at zero depth

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,13 @@
+**Project:** `wintree`
+**Author:** Maxim Dribny
+**Language:** Go
+**Description:** `wintree` is a command-line tool for generating directory tree listings. It is designed to be a fast, simple, and cross-platform alternative to the built-in `tree` command on various operating systems.
+**Key Features:**
+*   **Cross-Platform:** Single binary for Windows, macOS, and Linux.
+*   **Fast and Performant:** Efficiently skips large directories like `.git` and `node_modules`.
+*   **Powerful Filtering:** Supports excluding and including files and directories using glob patterns.
+*   **Flexible Output:** Can print to the console, save to a file, or copy to the clipboard.
+*   **Smart Defaults:** Automatically applies common ignore patterns based on the detected project type (e.g., Go, Node.js, Python).
+**Dependencies:**
+*   `github.com/spf13/cobra` for command-line argument parsing.
+*   `github.com/atotto/clipboard` for clipboard functionality.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -199,14 +199,21 @@ func findMatchingFiles(root string, f filter) ([]string, error) {
 			}
 		}
 
-		// If not in include mode, add all non-directory files.
-		if len(f.includeGlobs) == 0 && !d.IsDir() {
+		// If not in include mode, add everything that respects the depth limit.
+		if len(f.includeGlobs) == 0 {
 			// Also check depth for files when not in include mode.
 			relPath, err := filepath.Rel(root, path)
 			if err != nil {
 				return err
 			}
+
+			if path == root {
+				return nil
+			}
+
 			depth := strings.Count(relPath, string(filepath.Separator))
+
+			// Add any item that is within the allowed depth.
 			if maxDepth == -1 || depth < maxDepth+1 {
 				matchingPaths = append(matchingPaths, path)
 			}


### PR DESCRIPTION
Fixed a bug where directories where not correctly being recognized at a depth of zero or when there were no files found in the containing folders.

This PR fixes this so that the command now correctly displays **all** items which are found at each depth, preserving the inclusion and exclusion criteria. All tests are correctly passed.

```ps
go test ./cmd/                                                                                                                                                                                                                                                                                                                  
ok      github.com/maxdribny/wintree/cmd        0.326s
```