### PR TITLE
Add --full-path flag to display absolute directory path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build-release.ps1
 # Go coverage crap
 *.out
 coverage.out
+coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`wintree` is a cross-platform command-line tool for generating directory tree listings, written in Go. It's designed as a fast, simple alternative to built-in tree commands with advanced filtering capabilities.
+
+## Common Development Commands
+
+### Building
+- **Local development build**: `.\build-local.ps1`
+  - Builds for Windows with version info from git
+  - Installs to `$env:USERPROFILE\bin\wintree.exe`
+- **Release build**: `.\build-release.ps1 -Version v1.0.0`
+  - Builds for all platforms (Windows, macOS, Linux)
+  - Creates zip archives in `dist/` directory
+- **Manual build**: `go build .`
+
+### Testing
+- **Run all tests**: `go test -v ./...`
+- **Run with coverage**: `go test -coverprofile=coverage.out ./...`
+
+### Running
+- **Basic usage**: `go run . [path]`
+- **With flags**: `go run . --include "*.go" --exclude ".git"`
+
+## Code Architecture
+
+### Core Structure
+- **`main.go`**: Entry point that calls `cmd.Execute()`
+- **`cmd/root.go`**: Contains all CLI logic using Cobra framework
+  - Command definitions and flag handling
+  - Core file filtering and tree building logic
+  - Smart defaults for different project types
+
+### Key Components
+
+#### File Filtering System (`cmd/root.go`)
+- `filter` struct: Holds include/exclude glob patterns
+- `findMatchingFiles()`: Walks directory tree applying filters
+- `processFilters()`: Expands brace patterns (e.g., `*.{go,js}`)
+- Supports depth limiting with `--depth` flag
+
+#### Tree Building (`buildTreeOutput()`)
+- Converts file list to hierarchical tree representation
+- Uses Unicode box drawing characters (`├──`, `└──`, `│`)
+- Maintains proper indentation for nested directories
+
+#### Smart Defaults System
+- `detectProjectType()`: Analyzes directory for project indicators
+- `getSmartDefaults()`: Returns exclusion patterns for detected project type
+- Supports Go, Node.js, Python, Rust, Java, and other common project types
+
+#### Pattern Expansion
+- `expandBraces()`: Handles brace expansion like `*.{go,js}` → `["*.go", "*.js"]`
+- Uses regex to find and expand brace patterns
+
+### Dependencies
+- **Cobra**: CLI framework for command structure and flag handling
+- **atotto/clipboard**: System clipboard integration for `--copy` flag
+
+### Testing Structure
+All tests are in `cmd/` package:
+- `root_test.go`: Unit tests for core functionality
+- `integration_test.go`: End-to-end CLI tests
+- `benchmark_test.go`: Performance benchmarks
+
+Tests cover file filtering, pattern expansion, tree building, and CLI integration.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Tired of using complicated external tree packages with too many options and comp
 * **💻 Cross-Platform:** A single binary for Windows, macOS, and Linux.
 * **✅ Simple Syntax:** Intuitive flags that can be used in any order.
 * **🔍 Powerful Filtering:**
-    * **Exclude:** Easily ignore specific directories (`node_modules`), file extensions (`.log`), or patterns.
-    * **Include:** Use glob patterns (`*.go`, `*config*`) to create a whitelist of files to display.
+  * **Exclude:** Easily ignore specific directories (`node_modules`), file extensions (`.log`), or patterns.
+  * **Include:** Use glob patterns (`*.go`, `*config*`) to create a whitelist of files to display.
 * **📋 Flexible Output:**
-    * Print to the console (default).
-    * Save the output to a file (`--out`).
-    * Copy the output directly to the system clipboard (`--copy`).
+  * Print to the console (default).
+  * Save the output to a file (`--out`).
+  * Copy the output directly to the system clipboard (`--copy`).
 
 ## Installation
 
@@ -29,13 +29,12 @@ There are two easy ways to install `wintree`.
 
 This is the easiest way to get `wintree` without needing Go installed.
 
-1.  Go to the [**Latest Release**](https://github.com/maxdribny/wintree/releases/latest) page.
-2.  Download the archive for your operating system and architecture (e.g., `wintree_Windows_x86_64.zip` or `wintree_Darwin_arm64.tar.gz`).
-3.  Extract the `wintree` (or `wintree.exe`) binary.
-4.  Move the binary to a location in your system's `PATH` (e.g., `/usr/local/bin` on macOS/Linux or `C:\Windows\System32` on Windows) to make it runnable from anywhere.
+1. Go to the [**Latest Release**](https://github.com/maxdribny/wintree/releases/latest) page.
+2. Download the archive for your operating system and architecture (e.g., `wintree_Windows_x86_64.zip` or `wintree_Darwin_arm64.tar.gz`).
+3. Extract the `wintree` (or `wintree.exe`) binary.
+4. Move the binary to a location in your system's `PATH` (e.g., `/usr/local/bin` on macOS/Linux or `C:\Windows\System32` on Windows) to make it runnable from anywhere.
 
 ### 2. From Source (Requires Go)
-
 
 If you have Go installed, you can build and install `wintree` with a single command:
 
@@ -53,16 +52,18 @@ wintree [path] [flags]
 
 ### Flags
 
-| Flag                | Shorthand | Description                                                       | Example                                 |
-|---------------------|-----------|-------------------------------------------------------------------|-----------------------------------------|
-| `--exclude <str>`   | `-e`      | Exclude directories or extensions. Can be used multiple times.    | `-e .git -e .log`                        |
-| `--include <glob>`  | `-i`      | Whitelist files using glob patterns. Can be used multiple times.  | `-i "*.go" -i "Makefile"`               |
-| `--out <file>`      | `-o`      | Write the output to the specified file instead of the console.    | `-o my_tree.txt`                        |
-| `--copy`            | `-c`      | Copy the final output tree to the system clipboard.               | `-c`                                    |
-| `--smart-defaults`  | `-s`      | Apply smart defaults based on detected project type.              | `-s`                                    |
-| `--show-patterns`   | `-p`      | Show a guide for using glob patterns.                             | `-p`                                    |
-| `--version`         | `-v`      | Show version information.                                         | `-v`                                    |
-| `--help`            | `-h`      | Show the help message.                                            | `--help`                                |
+| Flag               | Shorthand | Description                                                      | Example                   |
+| ------------------ | --------- | ---------------------------------------------------------------- | ------------------------- |
+| `--exclude <str>`  | `-e`      | Exclude directories or extensions. Can be used multiple times.   | `-e .git -e .log`         |
+| `--include <glob>` | `-i`      | Whitelist files using glob patterns. Can be used multiple times. | `-i "*.go" -i "Makefile"` |
+| `--out <file>`     | `-o`      | Write the output to the specified file instead of the console.   | `-o my_tree.txt`          |
+| `--copy`           | `-c`      | Copy the final output tree to the system clipboard.              | `-c`                      |
+| `--smart-defaults` | `-s`      | Apply smart defaults based on detected project type.             | `-s`                      |
+| `--show-patterns`  | `-p`      | Show a guide for using glob patterns.                            | `-p`                      |
+| `--full-path`      | `-f`      | Show the full directory path above the tree output.              | `-f`                      |
+| `--depth <int>`    | `-d`      | Set maximum depth of directory tree (-1 for unlimited).          | `-d 3`                    |
+| `--version`        | `-v`      | Show version information.                                        | `-v`                      |
+| `--help`           | `-h`      | Show the help message.                                           | `--help`                  |
 
 ## Examples
 
@@ -98,6 +99,29 @@ Show all Go files, but ignore test files.
 wintree --include "*.go" --exclude "*_test.go"
 ```
 
+### Show Full Directory Path
+
+Display the absolute path of the directory being visualized above the tree output.
+
+```bash
+wintree --full-path
+```
+
+### Control Tree Depth
+
+Limit how deep the tree goes into subdirectories.
+
+```bash
+# Show only immediate children.
+wintree --depth 1
+
+# Show up to 3 levels deep.
+wintree --depth 3
+
+# Show entire tree (unlimited depth).
+wintree --depth -1
+```
+
 ### Saving to a File
 
 Generate a tree of your `src` folder and save it to `docs/directory-structure.txt`.
@@ -123,6 +147,7 @@ wintree --smart-defaults
 ```
 
 **Supported project types:**
+
 - **Go**: Excludes `vendor`, `*.exe`, `*.dll`, `*.so`, `*.dylib`
 - **Node.js/JavaScript**: Excludes `node_modules`, `dist`, `build`, `.next`, `coverage`, `*.log`
 - **Python**: Excludes `__pycache__`, `*.pyc`, `venv`, `.env`, `pip-log.txt`
@@ -162,11 +187,199 @@ cd wintree
 go build .
 ```
 
+## Developers
+
+This section covers the development workflow for contributing to wintree.
+
+### Prerequisites
+
+- Go 1.21 or later
+- Git
+- PowerShell (windows) or Bash (macOS/Linux)
+
+### Development Workflow
+
+#### 1. Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/maxdribny/wintree.git
+cd wintree
+
+# Create a feature branch
+git checkout -b feature/your-feature-name
+```
+
+### 2. Make Your Changes
+
+The project structure:
+
+- ```cmd/``` - Core application logic
+  - ```root.go``` - Main command implementation
+  - ```root_test.go``` - Unit tests
+  - ```integration_test.go``` - Integration tests
+  - ```benchmark_test.go``` - Performance benchmarks
+- ```main.go``` - Entry point
+
+### 3. Run Tests
+
+Always run tests before committing:
+
+```bash
+# Run all tests
+go test -v ./...
+
+
+# Run specific test
+go test -v -run TestBuildTreeOutput_WithFullPath ./cmd
+
+
+# Run with coverage (PowerShell)
+go test "-coverprofile=coverage.out" ./cmd
+
+# Run with coverage (macOS/Linux)
+go test -coverprofile=coverage.out ./cmd
+go tool voer -html=coverage.out # View in browser
+```
+
+#### 4. Run Benchmarks
+
+Track performance of your changes:
+
+```bash
+# Run All Benchmarks - Windows (PowerShell)
+./run-benchmarks.ps1
+
+# macOS/Linux
+go test -bench=. -benchmem -count=5 ./cmd
+```
+
+Compare performance before and after changes in your code:
+
+```bash
+# Before changes - Windows (PowerShell)
+go test "-bench=." -count=10 ./cmd > benchmarks/before.txt
+
+# macOS/Linux
+go test -bench=. -count=10 ./cmd > benchmarks/before.txt
+
+# After changes - Windows (PowerShell)
+go test "-bench=." -count=10 ./cmd > benchmarks/after.txt
+
+# macOS/Linux
+go test -bench=. -count=10 ./cmd > benchmarks/after.txt
+
+
+# Install benchstat and compare
+go install golang.org/x/perf/cmd/benchstat@latest
+benchstat benchmarks/before.txt benchmarks/after.txt
+```
+
+### 5. Build and Test Locally
+
+```bash
+# Build for local testing
+go build .
+./wintree --help
+
+# Or use the build script (Windows only)
+./build-local.ps1
+
+
+# Test your changes manually
+./wintree --full-path --depth 3
+./wintree -f -e node_modules -i "*.go"
+```
+
+### 6. Format and Lint
+
+```bash
+# Format code
+go fmt ./...
+
+
+# Run go vet
+go vet ./...
+```
+
+### 7. Commit and Push
+
+```bash
+# Stage changes
+git add -a
+
+# Commit with descriptive message
+git commit -m "feat: add full-path flag to display absolute directory path"
+
+# Push to your fork
+git push origin feature/your-feature-name
+```
+
+### 8. Create Pull Request
+
+1. Go to [GitHub - maxdribny/wintree](https://github.com/maxdribny/wintree)
+
+2. Click "New Pull Request"
+
+3. "Select your feature branch"
+
+4. Provide a clear description of changes
+
+5. Reference any related issues
+
+## Release Process
+
+For mainters creating a new release:
+
+```bash
+# 1. Ensure all tests pass
+go test -v ./...
+
+# 2. Update version in code if needed
+
+# 3. Build release artifacts
+./build-release.ps1 -Version v[version]
+
+
+# 4. Create and push tag
+git tag v0.4.0
+git push origin v0.4.0
+
+# 5. Create github release
+# - Upload the .zip files from dist/
+# - Add release notes
+```
+
+## Benchmark Tracking
+
+We track performance over time. When making changes:
+
+1. Run benchmarks before your changes
+
+2. Make your changes
+
+3. Run benchmarks after
+
+4. Include benchmark comparison in PR if significant changes
+
+Benchmark results are stored in ```benchmarks/``` for historical comparison.
+
 ## Contributing
 
 Contributions are welcome! If you find a bug or have a feature request, please open an issue. If you'd like to contribute code, please feel free to fork the repository and open a pull request.
 
+Code Style Guidelines:
+
+- Use meaningful variable names
+
+- Add comments for complex logic
+
+- Keep functions focused and small
+
+- Write tests for new functionality
+
+- Include documentation for user-facing changes in PRs
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-

--- a/benchmarks/bench_2025-09-13_16-37-04.txt
+++ b/benchmarks/bench_2025-09-13_16-37-04.txt
@@ -1,0 +1,26 @@
+goos: windows
+goarch: amd64
+pkg: github.com/maxdribny/wintree/cmd
+cpu: Intel(R) Core(TM) i9-14900K
+BenchmarkExpandBraces-32         	  684103	      1699 ns/op	    2289 B/op	      36 allocs/op
+BenchmarkExpandBraces-32         	  716468	      1706 ns/op	    2292 B/op	      36 allocs/op
+BenchmarkExpandBraces-32         	  700888	      1722 ns/op	    2293 B/op	      36 allocs/op
+BenchmarkExpandBraces-32         	  718351	      1714 ns/op	    2295 B/op	      36 allocs/op
+BenchmarkExpandBraces-32         	  645868	      1712 ns/op	    2294 B/op	      36 allocs/op
+BenchmarkProcessFilters-32       	  201344	      6050 ns/op	    9970 B/op	     134 allocs/op
+BenchmarkProcessFilters-32       	  198975	      6019 ns/op	    9966 B/op	     134 allocs/op
+BenchmarkProcessFilters-32       	  198409	      6037 ns/op	    9968 B/op	     134 allocs/op
+BenchmarkProcessFilters-32       	  202123	      6075 ns/op	    9970 B/op	     134 allocs/op
+BenchmarkProcessFilters-32       	  197798	      6021 ns/op	    9970 B/op	     134 allocs/op
+BenchmarkFindMatchingFiles-32    	    3192	    376024 ns/op	  146535 B/op	    1632 allocs/op
+BenchmarkFindMatchingFiles-32    	    3146	    365672 ns/op	  131814 B/op	    1542 allocs/op
+BenchmarkFindMatchingFiles-32    	    3090	    364986 ns/op	  146894 B/op	    1632 allocs/op
+BenchmarkFindMatchingFiles-32    	    3219	    366381 ns/op	  146766 B/op	    1632 allocs/op
+BenchmarkFindMatchingFiles-32    	    3252	    359947 ns/op	  146663 B/op	    1632 allocs/op
+BenchmarkBuildTreeOutput-32      	    3921	    303471 ns/op	  106160 B/op	    1125 allocs/op
+BenchmarkBuildTreeOutput-32      	    3957	    300895 ns/op	  106176 B/op	    1125 allocs/op
+BenchmarkBuildTreeOutput-32      	    3835	    303091 ns/op	  106178 B/op	    1125 allocs/op
+BenchmarkBuildTreeOutput-32      	    3943	    297753 ns/op	  104840 B/op	    1125 allocs/op
+BenchmarkBuildTreeOutput-32      	    3864	    302219 ns/op	  106177 B/op	    1125 allocs/op
+PASS
+ok  	github.com/maxdribny/wintree/cmd	32.763s

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ var (
 	showVersion      bool
 	useSmartDefaults bool
 	maxDepth         int
+	showFullPath     bool
 )
 
 type filter struct {
@@ -277,7 +278,12 @@ func findMatchingFiles(root string, f filter) ([]string, error) {
 // Construct the tree output as a string
 func buildTreeOutput(root string, paths []string) string {
 	if len(paths) == 0 {
-		return filepath.Base(root) + "\n"
+		var output strings.Builder
+		if showFullPath {
+			output.WriteString(root + "\n")
+		}
+		output.WriteString(filepath.Base(root) + "\n")
+		return output.String()
 	}
 
 	// Initialize a map to hold all nodes (directories and files)
@@ -312,6 +318,12 @@ func buildTreeOutput(root string, paths []string) string {
 
 	// Generate the tree output
 	var output strings.Builder
+
+	// Add full path if flag is set
+	if showFullPath {
+		output.WriteString(root + "\n")
+	}
+
 	// Start with the root directory name
 	output.WriteString(filepath.Base(root) + "\n")
 
@@ -388,6 +400,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Show version information")
 	rootCmd.Flags().BoolVarP(&useSmartDefaults, "smart-defaults", "s", false, "Apply smart defaults based on detected project type")
 	rootCmd.Flags().IntVarP(&maxDepth, "depth", "d", 1, "Set the maximum depth of the directory tree to display (-1 for unlimited). (Default = 1)")
+	rootCmd.Flags().BoolVarP(&showFullPath, "full-path", "f", false, "Show the full directory path of the current working directory. (Default = false)")
 }
 
 func printPatternHelp() {

--- a/run-benchmarks.ps1
+++ b/run-benchmarks.ps1
@@ -1,0 +1,25 @@
+# run-benchmarks.ps1
+
+param(
+    [int]$iterations = 5,
+    [string]$output = ""
+)
+
+Write-Host "Running benchmarks with $iterations iterations..." -ForegroundColor Green
+
+$timestamp = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
+$outputfile = if ($output) { $output } else { "benchmarks/bench_$timestamp.txt" }
+
+# Ensure the benchmarks directory exists
+New-Item -ItemType Directory -Path "benchmarks" -Force | Out-Null
+
+# Run benchmarks with proper escaping
+$result = go test "-bench=." -benchmem -count=$iterations ./cmd
+
+# Save to output file
+$result | Out-File -FilePath $outputfile
+
+# Also display to console
+Write-Host $result
+
+Write-Host "`nBenchmark results saved to: $outputfile" -ForegroundColor Cyan

--- a/run-benchmarks.ps1
+++ b/run-benchmarks.ps1
@@ -14,12 +14,9 @@ $outputfile = if ($output) { $output } else { "benchmarks/bench_$timestamp.txt" 
 New-Item -ItemType Directory -Path "benchmarks" -Force | Out-Null
 
 # Run benchmarks with proper escaping
-$result = go test "-bench=." -benchmem -count=$iterations ./cmd
+$result = go test "-bench=." -benchmem "-count=$iterations" ./cmd
 
 # Save to output file
 $result | Out-File -FilePath $outputfile
-
-# Also display to console
-Write-Host $result
 
 Write-Host "`nBenchmark results saved to: $outputfile" -ForegroundColor Cyan


### PR DESCRIPTION
This PR adds a new --full-path (-f) flag that displays the absolute directory path above the tree output. This feature improves clarity when sharing directory structures in documentation or when the exact location needs to be explicitly shown.

#### Changes Made
-**Added ```--full-path``` flag**: New boolean flag that controls whether to show the directory path
-**Modified ```buildTreeOutput``` function**: Updated to conditionally prepend the absolute path when the flag is enabled
-**Added comprehensive tests**:
  - Unit tests in ```root_test.go``` for the core funtionality
  - Integration tests in ```integration_test.go``` for flag behavior
-**Updated Documentation**: Added flag description and examples to README.md
-**Added developer documentation**: New "Developers" section in README with testing and contribution guidelines
